### PR TITLE
Fix build on ARM64 & bump ffmpeg-the-third

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sdl2 = { version = "0.38" }
 ringbuf = "0.4"
 parking_lot = "0.12"
 itertools = "0.14"
-nom = "8"
+nom = "7"
 
 [dev-dependencies]
 rfd = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sdl2-bundled = ["sdl2/bundled"]
 egui = "0.31"
 atomic = "0.6.0"
 bytemuck = { version = "1.19", features = ["derive"] }
-ffmpeg-the-third = "2.0.1"
+ffmpeg-the-third = "3.0.0"
 anyhow = "1.0.86"
 timer = "0.2.0"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ egui = "0.31"
 atomic = "0.6.0"
 bytemuck = { version = "1.19", features = ["derive"] }
 ffmpeg-the-third = "3.0.0"
+libc = "0.2.171"
 anyhow = "1.0.86"
 timer = "0.2.0"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,20 +19,20 @@ sdl2-bundled = ["sdl2/bundled"]
 
 [dependencies]
 egui = "0.31"
-atomic = "0.6.0"
-bytemuck = { version = "1.19", features = ["derive"] }
-ffmpeg-the-third = "3.0.0"
-libc = "0.2.171"
-anyhow = "1.0.86"
-timer = "0.2.0"
+atomic = "0.6"
+bytemuck = { version = "1", features = ["derive"] }
+ffmpeg-the-third = "3"
+libc = "0.2"
+anyhow = "1"
+timer = "0.2"
 chrono = "0.4"
-tempfile = { version = "3.12.0", optional = true }
-sdl2 = { version = "0.37.0" }
-ringbuf = "0.4.4"
-parking_lot = "0.12.3"
-itertools = "0.14.0"
-nom = "7.1.3"
+tempfile = { version = "3", optional = true }
+sdl2 = { version = "0.38" }
+ringbuf = "0.4"
+parking_lot = "0.12"
+itertools = "0.14"
+nom = "8"
 
 [dev-dependencies]
-rfd = "0.15.0"
+rfd = "0.15"
 eframe = "0.31"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use egui::{
     vec2, Align2, Color32, ColorImage, CornerRadius, FontId, Image, Pos2, Rect, Response, Sense,
     Spinner, TextureHandle, TextureOptions, Ui, Vec2,
 };
-use ffmpeg::error::EAGAIN;
+use libc::EAGAIN;
 use ffmpeg::ffi::{AVERROR, AV_TIME_BASE};
 use ffmpeg::format::context::input::Input;
 use ffmpeg::format::{input, Pixel};


### PR DESCRIPTION
Older `ffmpeg-the-third` has a build issue on ARM64 due to char being unsigned in the C ABI, so bump it to 3.0.0, use `EAGAIN` constant from libc